### PR TITLE
Add DRF-inspired utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,52 @@ middleware: [requireRole("admin")]
 ```
 
 ---
+
+## Django-Style Additions
+
+This package now provides lightweight abstractions inspired by Django REST Framework.
+
+### Serializers
+
+```ts
+import { Serializer } from "rest-core";
+import { t } from "@rbxts/t";
+
+const PlayerSchema = t.interface({
+        name: t.string,
+        age: t.number,
+});
+
+const PlayerSerializer = new Serializer(PlayerSchema);
+```
+
+### ViewSets
+
+```ts
+import { registerViewSet } from "rest-core";
+
+registerViewSet({
+        prefix: "players",
+        serializer: PlayerSerializer,
+        actions: {
+                create: ({ payload }) => {
+                        print(payload.name);
+                },
+        },
+});
+```
+
+### Apps
+
+```ts
+import { App } from "rest-core";
+
+const app = new App();
+app.addRoute({
+        name: "status",
+        handler: () => success("ok"),
+});
+app.include("api");
+```
+
+---

--- a/src/core/permissions.ts
+++ b/src/core/permissions.ts
@@ -8,9 +8,17 @@ export function requireRole(role: string): Middleware {
 }
 
 export function requireAuth(): Middleware {
-	return (ctx) => {
-		return ctx.player.GetAttribute("IsAuthenticated")
-			? { continue: true }
-			: { continue: false, error: "Unauthorized", code: 401 };
-	};
+        return (ctx) => {
+                return ctx.player.GetAttribute("IsAuthenticated")
+                        ? { continue: true }
+                        : { continue: false, error: "Unauthorized", code: 401 };
+        };
+}
+
+export function requireTokenAuth(token: string): Middleware {
+        return (ctx) => {
+                return ctx.player.GetAttribute("AuthToken") === token
+                        ? { continue: true }
+                        : { continue: false, error: "Unauthorized", code: 401 };
+        };
 }

--- a/src/drf/apps.ts
+++ b/src/drf/apps.ts
@@ -1,0 +1,14 @@
+import type { RegisteredRoute } from "..";
+import { registerRoutes } from "../core/router";
+
+export class App {
+        private routes: RegisteredRoute<unknown>[] = [];
+
+        addRoute(route: RegisteredRoute<unknown>) {
+                this.routes.push(route);
+        }
+
+        include(namespace: string) {
+                registerRoutes(namespace, this.routes as never[]);
+        }
+}

--- a/src/drf/models.ts
+++ b/src/drf/models.ts
@@ -1,0 +1,19 @@
+export class Model<T extends Record<string, unknown>> {
+        protected data: T;
+
+        constructor(initial: T) {
+                this.data = initial;
+        }
+
+        getFields() {
+                return this.data;
+        }
+
+        save() {
+                // placeholder for persistent storage
+        }
+
+        delete() {
+                // placeholder for deletion logic
+        }
+}

--- a/src/drf/serializer.ts
+++ b/src/drf/serializer.ts
@@ -1,0 +1,22 @@
+import type { InferTType } from "..";
+
+export class Serializer<S extends (val: unknown) => unknown> {
+        constructor(public schema: S) {}
+
+        validate(data: unknown): data is InferTType<S> {
+                const result = this.schema(data);
+                const isValid = typeIs(result, "boolean") ? result : (result as [boolean])[0];
+                return isValid as boolean;
+        }
+
+        deserialize(data: unknown): InferTType<S> {
+                if (!this.validate(data)) {
+                        throw `Invalid payload`;
+                }
+                return data as InferTType<S>;
+        }
+
+        serialize(data: InferTType<S>): unknown {
+                return data as unknown;
+        }
+}

--- a/src/drf/viewsets.ts
+++ b/src/drf/viewsets.ts
@@ -1,0 +1,56 @@
+import type { RouteContext, RegisteredRoute } from "..";
+import { registerRoute } from "../core/router";
+import type { Serializer } from "./serializer";
+import type { InferTType } from "..";
+const anySchema = (value: unknown) => true;
+
+export interface ViewSetOptions<S extends (val: unknown) => unknown> {
+        prefix: string;
+        serializer: Serializer<S>;
+        actions: Partial<{
+                list: RegisteredRoute<void>["handler"];
+                retrieve: RegisteredRoute<{ id: string }>["handler"];
+                create: RegisteredRoute<InferTType<S>>["handler"];
+                update: RegisteredRoute<InferTType<S>>["handler"];
+                destroy: RegisteredRoute<{ id: string }>["handler"];
+        }>;
+}
+
+export function registerViewSet<S extends (val: unknown) => unknown>(opts: ViewSetOptions<S>) {
+        const { prefix, actions, serializer } = opts;
+        if (actions.list) {
+                registerRoute<typeof anySchema>({
+                        name: `${prefix}:list`,
+                        schema: anySchema,
+                        handler: actions.list as unknown as RegisteredRoute<unknown>["handler"],
+                });
+        }
+        if (actions.retrieve) {
+                registerRoute<typeof anySchema>({
+                        name: `${prefix}:retrieve`,
+                        schema: anySchema,
+                        handler: actions.retrieve as unknown as RegisteredRoute<unknown>["handler"],
+                });
+        }
+        if (actions.create) {
+                registerRoute({
+                        name: `${prefix}:create`,
+                        schema: serializer.schema,
+                        handler: actions.create,
+                });
+        }
+        if (actions.update) {
+                registerRoute({
+                        name: `${prefix}:update`,
+                        schema: serializer.schema,
+                        handler: actions.update,
+                });
+        }
+        if (actions.destroy) {
+                registerRoute<typeof anySchema>({
+                        name: `${prefix}:destroy`,
+                        schema: anySchema,
+                        handler: actions.destroy as unknown as RegisteredRoute<unknown>["handler"],
+                });
+        }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ export * from "./plugins/signal";
 export * from "./utils/deepClone";
 export * from "./utils/routerBridge";
 export * from "./client/websocket";
+export * from "./drf/serializer";
+export * from "./drf/models";
+export * from "./drf/viewsets";
+export * from "./drf/apps";
 
 export function ws<T>(route: string, handler: (ctx: WebSocketContext<T>) => void) {
 	createMockWebSocket(route, handler);


### PR DESCRIPTION
## Summary
- add basic serializers, models, viewsets and apps utilities
- extend permissions with token-based auth
- re-export new modules and document their usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878415a9e50832c83aecdb5984d8209